### PR TITLE
PCB bringup - measurements, shunts, heaters, CAN

### DIFF
--- a/makefile
+++ b/makefile
@@ -186,4 +186,4 @@ endif
 
 # Upload program to board
 upload: $(PROG)
-	avrdude -c $(PGMR) -p $(DEVICE) -P $(PORT) -U flash:w:./build/$^.hex
+	avrdude -c $(PGMR) -C ./lib-common/avrdude.conf -p $(DEVICE) -P $(PORT) -U flash:w:./build/$^.hex

--- a/manual_tests/can_commands_test/can_commands_test.c
+++ b/manual_tests/can_commands_test/can_commands_test.c
@@ -354,7 +354,7 @@ int main(void) {
     print("\n\n\nStarting commands test\n\n");
 
     // Change these as necessary for testing
-    sim_local_actions = true;
+    sim_local_actions = false;
     sim_obc = true;
     print_can_msgs = true;
 
@@ -367,15 +367,19 @@ int main(void) {
     set_uart_rx_cb(uart_cb);
 
     while(1) {
-        print_next_tx_msg();
-        if (sim_obc) {
-            sim_send_next_tx_msg();
-        } else {
-            send_next_tx_msg();
+        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+            print_next_tx_msg();
+            if (sim_obc) {
+                sim_send_next_tx_msg();
+            } else {
+                send_next_tx_msg();
+            }
         }
 
-        print_next_rx_msg();
-        process_next_rx_msg();
+        ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
+            print_next_rx_msg();
+            process_next_rx_msg();
+        }
     }
 
     return 0;

--- a/manual_tests/can_commands_test/can_commands_test.c
+++ b/manual_tests/can_commands_test/can_commands_test.c
@@ -163,12 +163,12 @@ void process_eps_hk_tx_msg(uint8_t* tx_msg) {
             print("Mag Z:");
             print_imu_data(raw_data);
             break;
-        case CAN_EPS_HK_GET_DAC1:
-            print("DAC Setpoint 1:");
+        case CAN_EPS_HK_HEAT_SP1:
+            print("Heater Setpoint 1:");
             print_therm_temp(raw_data);
             break;
-        case CAN_EPS_HK_GET_DAC2:
-            print("DAC Setpoint 2:");
+        case CAN_EPS_HK_HEAT_SP2:
+            print("Heater Setpoint 2:");
             print_therm_temp(raw_data);
             break;
         default:
@@ -176,7 +176,7 @@ void process_eps_hk_tx_msg(uint8_t* tx_msg) {
     }
 
     uint8_t next_field_num = tx_msg[2] + 1;
-    if (next_field_num < CAN_EPS_HK_GET_COUNT) {
+    if (next_field_num < CAN_EPS_HK_FIELD_COUNT) {
         enqueue_rx_msg(CAN_EPS_HK, next_field_num);
     }
 }

--- a/manual_tests/heaters_test/heaters_test.c
+++ b/manual_tests/heaters_test/heaters_test.c
@@ -64,26 +64,24 @@ uint8_t adc_channels_len = sizeof(adc_channels) / sizeof(adc_channels[0]);
 
 
 void read_thermistor_data_fn(void) {
-    //Read all of the thermistors' voltage from adc
-    fetch_all_adc_channels(&adc);
-
     print("\n");
-    print("Channel, Temperature (C), Raw (12 bits), Voltage (V), Resistance (kohms)\n");
+    print("Channel, Raw (12 bits), Voltage (V), Resistance (kohms), Temperature (C)\n");
 
     //Find resistance for each channel
     //only calculate it for the thermistors specified in adc_channels
     for (uint8_t i = 0; i < adc_channels_len; i++) {
         // Read ADC channel data
         uint8_t channel = adc_channels[i];
+        fetch_adc_channel(&adc, channel);
         uint16_t raw_data = read_adc_channel(&adc, channel);
 
         double voltage = adc_raw_data_to_raw_vol(raw_data);
         //Convert adc voltage to resistance of thermistor
         double resistance = therm_vol_to_res(voltage);
         //Convert resistance to temperature of thermistor
-        double temperature = therm_res_to_temp(resistance);
+        double temperature = adc_raw_data_to_therm_temp(raw_data);
 
-        print("%u: %.3f, 0x%.3X, %.3f, %.3f\n", channel, temperature, raw_data, voltage, resistance);
+        print("%u: 0x%.3X, %.3f, %.3f, %.3f\n", channel, raw_data, voltage, resistance, temperature);
     }
 }
 
@@ -152,6 +150,12 @@ uint8_t uart_cb(const uint8_t* data, uint8_t len) {
 
 int main(void) {
     init_uart();
+
+    // Set the IMU CSn (PD0) high (because it doesn't have a pullup resistor)
+    // so it doesn't interfere with MISO line
+    init_cs(PD0, &DDRD);
+    set_cs_high(PD0, &PORTD);
+
     init_spi();
     init_dac(&dac);
     init_adc(&adc);

--- a/manual_tests/heaters_test/heaters_test.c
+++ b/manual_tests/heaters_test/heaters_test.c
@@ -88,25 +88,25 @@ void read_thermistor_data_fn(void) {
 }
 
 void turn_heater_1_on_fn(void) {
-    set_heater_1_setpoint_temp(100);
+    set_heater_1_temp_setpoint(100);
     print("Set heater 1 setpoint (DAC A) = 100 C\n");
     print("Heater 1 should be ON\n");
 }
 
 void turn_heater_1_off_fn(void) {
-    set_heater_1_setpoint_temp(0);
+    set_heater_1_temp_setpoint(0);
     print("Set heater 1 setpoint (DAC A) = 0 C\n");
     print("Heater 1 should be OFF\n");
 }
 
 void turn_heater_2_on_fn(void) {
-    set_heater_2_setpoint_temp(100);
+    set_heater_2_temp_setpoint(100);
     print("Set heater 2 setpoint (DAC B) = 100 C\n");
     print("Heater 2 should be ON\n");
 }
 
 void turn_heater_2_off_fn(void) {
-    set_heater_2_setpoint_temp(0);
+    set_heater_2_temp_setpoint(0);
     print("Set heater 2 setpoint (DAC B) = 0 C\n");
     print("Heater 2 should be OFF\n");
 }

--- a/manual_tests/heaters_test/heaters_test.c
+++ b/manual_tests/heaters_test/heaters_test.c
@@ -3,6 +3,7 @@ Test heaters by typing in commands over UART to manually turn on and off heaters
 Also display thermistor measurements.
 */
 
+#include <adc/adc.h>
 #include <uart/uart.h>
 
 #include "../../src/devices.h"
@@ -64,7 +65,7 @@ uint8_t adc_channels_len = sizeof(adc_channels) / sizeof(adc_channels[0]);
 
 void read_thermistor_data_fn(void) {
     //Read all of the thermistors' voltage from adc
-    fetch_all(&adc);
+    fetch_all_adc_channels(&adc);
 
     print("\n");
     print("Channel, Temperature (C), Raw (12 bits), Voltage (V), Resistance (kohms)\n");
@@ -74,7 +75,7 @@ void read_thermistor_data_fn(void) {
     for (uint8_t i = 0; i < adc_channels_len; i++) {
         // Read ADC channel data
         uint8_t channel = adc_channels[i];
-        uint16_t raw_data = read_channel(&adc, channel);
+        uint16_t raw_data = read_adc_channel(&adc, channel);
 
         double voltage = adc_raw_data_to_raw_vol(raw_data);
         //Convert adc voltage to resistance of thermistor

--- a/manual_tests/makefile
+++ b/manual_tests/makefile
@@ -6,11 +6,13 @@
 
 # Parameters that might need to be changed, depending on the repository
 #-------------------------------------------------------------------------------
+# Path to lib-common (relative to current directory)
+LIB_COMMON = ../../lib-common
 # Includes (header files)
-INCLUDES = -I../../lib-common/include
+INCLUDES = -I$(LIB_COMMON)/include
 # Libraries from lib-common to link
 # For some reason, conversions needs to come after dac or else it gives an error
-LIB = -L../../lib-common/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
+LIB = -L$(LIB_COMMON)/lib -ladc -lcan -ldac -lconversions -lheartbeat -lpex -lqueue -lspi -lstack -ltest -ltimer -luart -lutilities -lwatchdog -lprintf_flt -lm
 # Name of microcontroller ("32m1" or "64m1")
 MCU = 64m1
 #-------------------------------------------------------------------------------
@@ -127,8 +129,8 @@ lib-common:
 	@echo "Fetching latest version of lib-common..."
 	git submodule update --remote
 	@echo "Compiling lib-common..."
-	make -C ../../lib-common clean MCU=$(MCU)
-	make -C ../../lib-common MCU=$(MCU)
+	make -C $(LIB_COMMON) clean MCU=$(MCU)
+	make -C $(LIB_COMMON) MCU=$(MCU)
 
 # Create a file called eeprom.bin, which contains a raw binary copy of the micro's EEPROM memory.
 # View the contents of the binary file in hex
@@ -144,4 +146,4 @@ endif
 
 # Upload .hex program to device
 upload: $(PROG)
-	avrdude -p $(DEVICE) -c $(PGMR) -P $(PORT) -U flash:w:./$^.hex
+	avrdude -p $(DEVICE) -c $(PGMR) -C $(LIB_COMMON)/avrdude.conf -P $(PORT) -U flash:w:./$^.hex

--- a/manual_tests/measurements_test/measurements_test.c
+++ b/manual_tests/measurements_test/measurements_test.c
@@ -1,6 +1,5 @@
 #include <uart/uart.h>
 #include <adc/adc.h>
-#include <adc/eps.h>
 #include <spi/spi.h>
 #include <conversions/conversions.h>
 
@@ -8,8 +7,8 @@
 #include "../../src/measurements.h"
 
 void read_voltage(uint8_t channel) {
-    fetch_channel(&adc, channel);
-    uint16_t raw_data = read_channel(&adc, channel);
+    fetch_adc_channel(&adc, channel);
+    uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
     double voltage = adc_raw_vol_to_eps_vol(raw_voltage);
     print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Voltage: %.6f V\n",
@@ -17,8 +16,8 @@ void read_voltage(uint8_t channel) {
 }
 
 void read_current(uint8_t channel) {
-    fetch_channel(&adc, channel);
-    uint16_t raw_data = read_channel(&adc, channel);
+    fetch_adc_channel(&adc, channel);
+    uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
     double current = adc_raw_vol_to_eps_cur(raw_voltage);
     print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Current: %.6f A\n",
@@ -26,8 +25,8 @@ void read_current(uint8_t channel) {
 }
 
 void read_therm(uint8_t channel) {
-    fetch_channel(&adc, channel);
-    uint16_t raw_data = read_channel(&adc, channel);
+    fetch_adc_channel(&adc, channel);
+    uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
     double temp = adc_raw_data_to_therm_temp(raw_data);
     print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Temperature: %.6f C\n",

--- a/manual_tests/measurements_test/measurements_test.c
+++ b/manual_tests/measurements_test/measurements_test.c
@@ -6,31 +6,31 @@
 #include "../../src/devices.h"
 #include "../../src/measurements.h"
 
-void read_voltage(uint8_t channel) {
+void read_voltage(char* name, uint8_t channel) {
     fetch_adc_channel(&adc, channel);
     uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
     double voltage = adc_raw_data_to_eps_vol(raw_data);
-    print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Voltage: %.6f V\n",
-            channel, raw_data, raw_voltage, voltage);
+    print("%s, %u, 0x%04x, %.6f V, %.6f V\n",
+            name, channel, raw_data, raw_voltage, voltage);
 }
 
-void read_current(uint8_t channel) {
+void read_current(char* name, uint8_t channel) {
     fetch_adc_channel(&adc, channel);
     uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
     double current = adc_raw_data_to_eps_cur(raw_data);
-    print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Current: %.6f A\n",
-            channel, raw_data, raw_voltage, current);
+    print("%s, %u, 0x%04x, %.6f V, %.6f A\n",
+            name, channel, raw_data, raw_voltage, current);
 }
 
-void read_therm(uint8_t channel) {
+void read_therm(char* name, uint8_t channel) {
     fetch_adc_channel(&adc, channel);
     uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
     double temp = adc_raw_data_to_therm_temp(raw_data);
-    print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Temperature: %.6f C\n",
-            channel, raw_data, raw_voltage, temp);
+    print("%s, %u, 0x%04x, %.6f V, %.6f C\n",
+            name, channel, raw_data, raw_voltage, temp);
 }
 
 
@@ -39,6 +39,11 @@ void read_therm(uint8_t channel) {
 int main(void) {
     init_uart();
     print("\n\nUART initialized\n");
+
+    // Set the IMU CSn (PD0) high (because it doesn't have a pullup resistor)
+    // so it doesn't interfere with the ADC's output on the MISO line
+    init_cs(PD0, &DDRD);
+    set_cs_high(PD0, &PORTD);
 
     init_spi();
     print("SPI Initialized\n");
@@ -49,30 +54,19 @@ int main(void) {
     print("\nStarting test\n\n");
 
     while(1) {
-        print("BB VOUT\n");
-        read_voltage(MEAS_BB_VOUT);
-        print("BB IOUT\n");
-        read_current(MEAS_BB_IOUT);
-        print("-Y IOUT\n");
-        read_current(MEAS_NEG_Y_IOUT);
-        print("+X IOUT\n");
-        read_current(MEAS_POS_X_IOUT);
-        print("-Y IOUT\n");
-        read_current(MEAS_POS_Y_IOUT);
-        print("-X IOUT\n");
-        read_current(MEAS_NEG_X_IOUT);
-        print("THERM 1\n");
-        read_therm(MEAS_THERM_1);
-        print("THERM 2\n");
-        read_therm(MEAS_THERM_2);
-        print("PACK VOUT\n");
-        read_voltage(MEAS_PACK_VOUT);
-        print("PACK IOUT\n");
-        read_current(MEAS_PACK_IOUT);
-        print("BT IOUT\n");
-        read_current(MEAS_BT_IOUT);
-        print("BT VOUT\n");
-        read_voltage(MEAS_BT_VOUT);
+        print("Name, Channel, Raw Data, Raw Voltage, Converted Data\n");
+        read_voltage("BB VOUT", MEAS_BB_VOUT);
+        read_current("BB IOUT", MEAS_BB_IOUT);
+        read_current("-Y IOUT", MEAS_NEG_Y_IOUT);
+        read_current("+X IOUT", MEAS_POS_X_IOUT);
+        read_current("-Y IOUT", MEAS_POS_Y_IOUT);
+        read_current("-X IOUT", MEAS_NEG_X_IOUT);
+        read_therm("THERM 1", MEAS_THERM_1);
+        read_therm("THERM 2", MEAS_THERM_2);
+        read_voltage("PACK VOUT", MEAS_PACK_VOUT);
+        read_current("PACK IOUT", MEAS_PACK_IOUT);
+        read_current("BT IOUT", MEAS_BT_IOUT);
+        read_voltage("BT VOUT", MEAS_BT_VOUT);
 
         print("\n");
         _delay_ms(5000);

--- a/manual_tests/measurements_test/measurements_test.c
+++ b/manual_tests/measurements_test/measurements_test.c
@@ -10,7 +10,7 @@ void read_voltage(uint8_t channel) {
     fetch_adc_channel(&adc, channel);
     uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
-    double voltage = adc_raw_vol_to_eps_vol(raw_voltage);
+    double voltage = adc_raw_data_to_eps_vol(raw_data);
     print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Voltage: %.6f V\n",
             channel, raw_data, raw_voltage, voltage);
 }
@@ -19,7 +19,7 @@ void read_current(uint8_t channel) {
     fetch_adc_channel(&adc, channel);
     uint16_t raw_data = read_adc_channel(&adc, channel);
     double raw_voltage = adc_raw_data_to_raw_vol(raw_data);
-    double current = adc_raw_vol_to_eps_cur(raw_voltage);
+    double current = adc_raw_data_to_eps_cur(raw_data);
     print("Channel: %u, Raw Data: 0x%04x, Raw Voltage: %.6f V, Current: %.6f A\n",
             channel, raw_data, raw_voltage, current);
 }
@@ -53,13 +53,13 @@ int main(void) {
         read_voltage(MEAS_BB_VOUT);
         print("BB IOUT\n");
         read_current(MEAS_BB_IOUT);
-        print("NEG Y IOUT\n");
+        print("-Y IOUT\n");
         read_current(MEAS_NEG_Y_IOUT);
-        print("POS X IOUT\n");
+        print("+X IOUT\n");
         read_current(MEAS_POS_X_IOUT);
-        print("POS Y IOUT\n");
+        print("-Y IOUT\n");
         read_current(MEAS_POS_Y_IOUT);
-        print("NEG X IOUT\n");
+        print("-X IOUT\n");
         read_current(MEAS_NEG_X_IOUT);
         print("THERM 1\n");
         read_therm(MEAS_THERM_1);

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -18,6 +18,9 @@ queue_t can_tx_msg_queue;
 // system on any PCB without any peripherals
 bool sim_local_actions = false;
 
+void handle_rx_hk(uint8_t* rx_msg);
+void handle_rx_ctrl(uint8_t* rx_msg);
+
 
 // Checks the RX message queue and processes the first message (if it exists)
 void handle_rx_msg(void) {
@@ -31,50 +34,54 @@ void handle_rx_msg(void) {
         dequeue(&can_rx_msg_queue, rx_msg);
     }
 
-    // Message to transmit
-    // Send back the message type and field number
-    uint8_t tx_msg[8] = {0x00};
-    tx_msg[0] = 0; // TODO
-    tx_msg[1] = rx_msg[1];
-    tx_msg[2] = rx_msg[2];
+    switch (rx_msg[1]) {
+        case CAN_EPS_HK:
+            handle_rx_hk(rx_msg);
+            break;
+        case CAN_EPS_CTRL:
+            handle_rx_ctrl(rx_msg);
+            break;
+        default:
+            break;
+    }
+}
 
+void handle_rx_hk(uint8_t* rx_msg) {
+    uint8_t field_num = rx_msg[2];
     uint32_t data = 0;
 
-    // Check message type
-    if (rx_msg[1] == CAN_EPS_HK) {
-        uint8_t field_num = rx_msg[2];
-
-        if ((CAN_EPS_HK_BB_VOL <= field_num) &&
-                (field_num <= CAN_EPS_HK_BAT_TEMP2)) {
-            if (sim_local_actions) {
-                // use 11 bits for ADC data
-                data = random() & 0x7FF;
-            } else {
-                uint8_t channel = field_num - CAN_EPS_HK_BB_VOL;
-                fetch_channel(&adc, channel);
-                data = read_channel(&adc, channel);
-            }
-        }
-
-        else if ((CAN_EPS_HK_IMU_ACC_X <= field_num) &&
-                (field_num <= CAN_EPS_HK_IMU_MAG_Z)) {
-            // TODO - get IMU data
-            data = random() & 0xFFFF;
-        }
-
-        else if ((CAN_EPS_HK_GET_DAC1 <= field_num) &&
-                (field_num <= CAN_EPS_HK_GET_DAC2)) {
-            // TODO - get DAC data
+    // Check field number
+    if ((CAN_EPS_HK_BB_VOL <= field_num) &&
+            (field_num <= CAN_EPS_HK_BAT_TEMP2)) {
+        if (sim_local_actions) {
+            // use 11 bits for ADC data
             data = random() & 0x7FF;
+        } else {
+            uint8_t channel = field_num - CAN_EPS_HK_BB_VOL;
+            fetch_adc_channel(&adc, channel);
+            data = read_adc_channel(&adc, channel);
         }
+    }
 
-        else if ((CAN_EPS_HK_SET_DAC1 <= field_num) &&
-                (field_num <= CAN_EPS_HK_SET_DAC2)) {
-            // TODO - set DAC data
+    else if ((CAN_EPS_HK_IMU_ACC_X <= field_num) &&
+            (field_num <= CAN_EPS_HK_IMU_MAG_Z)) {
+        // TODO - get IMU data
+        data = random() & 0xFFFF;
+    }
+
+    else if (field_num == CAN_EPS_HK_HEAT_SP1) {
+        if (sim_local_actions) {
+            data = random() & 0x7FF;
+        } else {
+            data = dac.raw_voltage_a;
         }
+    }
 
-        else {
-            return;
+    else if (field_num == CAN_EPS_HK_HEAT_SP2) {
+        if (sim_local_actions) {
+            data = random() & 0x7FF;
+        } else {
+            data = dac.raw_voltage_b;
         }
     }
 
@@ -83,9 +90,50 @@ void handle_rx_msg(void) {
         return;
     }
 
+    // Message to transmit
+    // Send back the message type and field number
+    uint8_t tx_msg[8] = {0x00};
+    tx_msg[0] = 0; // TODO
+    tx_msg[1] = rx_msg[1];
+    tx_msg[2] = rx_msg[2];
     tx_msg[3] = (data >> 16) & 0xFF;
     tx_msg[4] = (data >> 8) & 0xFF;
     tx_msg[5] = data & 0xFF;
+
+    // Enqueue TX data to transmit
+    enqueue(&can_tx_msg_queue, tx_msg);
+    // print("Enqueued TX\n");
+    // print_bytes(tx_msg, 8);
+}
+
+
+void handle_rx_ctrl(uint8_t* rx_msg) {
+    uint8_t field_num = rx_msg[2];
+    uint32_t data =
+        (((uint32_t) rx_msg[3]) << 16) |
+        (((uint32_t) rx_msg[4]) << 8) |
+        ((uint32_t) rx_msg[5]);
+
+    // Check field number
+    if (field_num == CAN_EPS_CTRL_HEAT_SP1) {
+        set_dac_raw_voltage(&dac, DAC_A, (uint16_t) data);
+    }
+
+    else if (field_num == CAN_EPS_CTRL_HEAT_SP2) {
+        set_dac_raw_voltage(&dac, DAC_B, (uint16_t) data);
+    }
+
+    // If the field number is not recognized, return before enqueueing
+    else {
+        return;
+    }
+
+    // Message to transmit
+    // Send back the message type and field number
+    uint8_t tx_msg[8] = {0x00};
+    tx_msg[0] = 0; // TODO
+    tx_msg[1] = rx_msg[1];
+    tx_msg[2] = rx_msg[2];
 
     // Enqueue TX data to transmit
     enqueue(&can_tx_msg_queue, tx_msg);

--- a/src/can_commands.c
+++ b/src/can_commands.c
@@ -52,7 +52,7 @@ void handle_rx_hk(uint8_t* rx_msg) {
 
     // Check field number
     if ((CAN_EPS_HK_BB_VOL <= field_num) &&
-            (field_num <= CAN_EPS_HK_BAT_TEMP2)) {
+            (field_num <= CAN_EPS_HK_BT_VOL)) {
         if (sim_local_actions) {
             // use 11 bits for ADC data
             data = random() & 0x7FF;
@@ -61,12 +61,6 @@ void handle_rx_hk(uint8_t* rx_msg) {
             fetch_adc_channel(&adc, channel);
             data = read_adc_channel(&adc, channel);
         }
-    }
-
-    else if ((CAN_EPS_HK_IMU_ACC_X <= field_num) &&
-            (field_num <= CAN_EPS_HK_IMU_MAG_Z)) {
-        // TODO - get IMU data
-        data = random() & 0xFFFF;
     }
 
     else if (field_num == CAN_EPS_HK_HEAT_SP1) {
@@ -83,6 +77,12 @@ void handle_rx_hk(uint8_t* rx_msg) {
         } else {
             data = dac.raw_voltage_b;
         }
+    }
+
+    else if ((CAN_EPS_HK_IMU_ACC_X <= field_num) &&
+            (field_num <= CAN_EPS_HK_IMU_MAG_Z)) {
+        // TODO - get IMU data
+        data = random() & 0x7FFF;
     }
 
     // If the message type is not recognized, return before enqueueing

--- a/src/devices.c
+++ b/src/devices.c
@@ -2,47 +2,46 @@
 
 // ADC
 pin_info_t adc_cs = {
-    .port = &ADC_CS_PORT_EPS,
-    .ddr = &ADC_CS_DDR_EPS,
-    .pin = ADC_CS_PIN_EPS
+    .port = &ADC_CS_PORT,
+    .ddr = &ADC_CS_DDR,
+    .pin = ADC_CS_PIN
 };
 adc_t adc = {
-    .channels = 0x0fff, // poll channels 0-11 in auto-1 mode
+    .auto_channels = 0x0fff, // poll channels 0-11 in auto-1 mode
     .cs = &adc_cs
 };
 
-// PEX
-pin_info_t pex_cs = {
-    .port = &PEX_CS_PORT_EPS,
-    .ddr = &PEX_CS_DDR_EPS,
-    .pin = PEX_CS_PIN_EPS
-};
-pin_info_t pex_rst = {
-    .port = &PEX_RST_PORT_EPS,
-    .ddr = &PEX_RST_DDR_EPS,
-    .pin = PEX_RST_PIN_EPS
-};
-pex_t pex = {
-    .addr = PEX_ADDR_EPS,
-    .cs = &pex_cs,
-    .rst = &pex_rst
-};
-
 // DAC
-// TODO - make constants
 pin_info_t dac_cs = {
-    .pin = PB4,
-    .ddr = &DDRB,
-    .port = &PORTB
+    .pin = DAC_CS_PIN,
+    .ddr = &DAC_CS_DDR,
+    .port = &DAC_CS_PORT
 };
 pin_info_t dac_clr = {
-    .pin = PC7,
-    .ddr = &DDRC,
-    .port = &PORTC
+    .pin = DAC_CLR_PIN,
+    .ddr = &DAC_CLR_DDR,
+    .port = &DAC_CLR_PORT
 };
 dac_t dac = {
     .cs = &dac_cs,
     .clr = &dac_clr,
     .raw_voltage_a = 0,
     .raw_voltage_b = 0
+};
+
+// PEX
+pin_info_t pex_cs = {
+    .port = &PEX_CS_PORT,
+    .ddr = &PEX_CS_DDR,
+    .pin = PEX_CS_PIN
+};
+pin_info_t pex_rst = {
+    .port = &PEX_RST_PORT,
+    .ddr = &PEX_RST_DDR,
+    .pin = PEX_RST_PIN
+};
+pex_t pex = {
+    .addr = PEX_ADDR,
+    .cs = &pex_cs,
+    .rst = &pex_rst
 };

--- a/src/devices.h
+++ b/src/devices.h
@@ -21,18 +21,17 @@
 #define DAC_CLR_DDR  DDRC
 
 // PEX CS
-#define PEX_CS_PIN  PB5
-#define PEX_CS_PORT PORTB
-#define PEX_CS_DDR  DDRB
+#define PEX_CS_PIN  PC1
+#define PEX_CS_PORT PORTC
+#define PEX_CS_DDR  DDRC
 
 // PEX RST
-#define PEX_RST_PIN  PB4
-#define PEX_RST_PORT PORTB
-#define PEX_RST_DDR  DDRB
+#define PEX_RST_PIN  PD1
+#define PEX_RST_PORT PORTD
+#define PEX_RST_DDR  DDRD
 
 // PEX address
-// TODO
-#define PEX_ADDR 0
+#define PEX_ADDR 0b001
 
 extern adc_t adc;
 extern pex_t pex;

--- a/src/devices.h
+++ b/src/devices.h
@@ -2,10 +2,37 @@
 #define DEVICES_H
 
 #include <adc/adc.h>
-#include <adc/eps.h>
 #include <dac/dac.h>
-#include <pex/eps.h>
 #include <pex/pex.h>
+
+// ADC CS
+#define ADC_CS_PIN  PB2
+#define ADC_CS_PORT PORTB
+#define ADC_CS_DDR  DDRB
+
+// DAC CS
+#define DAC_CS_PIN  PB4
+#define DAC_CS_PORT PORTB
+#define DAC_CS_DDR  DDRB
+
+// DAC CLR
+#define DAC_CLR_PIN  PC7
+#define DAC_CLR_PORT PORTC
+#define DAC_CLR_DDR  DDRC
+
+// PEX CS
+#define PEX_CS_PIN  PB5
+#define PEX_CS_PORT PORTB
+#define PEX_CS_DDR  DDRB
+
+// PEX RST
+#define PEX_RST_PIN  PB4
+#define PEX_RST_PORT PORTB
+#define PEX_RST_DDR  DDRB
+
+// PEX address
+// TODO
+#define PEX_ADDR 0
 
 extern adc_t adc;
 extern pex_t pex;

--- a/src/general.c
+++ b/src/general.c
@@ -6,6 +6,12 @@ void init_eps(void) {
     // UART
     init_uart();
 
+    // TODO - remove and call init_imu()
+    // Set the IMU CSn (PD0) high (because it doesn't have a pullup resistor)
+    // so it doesn't interfere with the MOSI/MISO lines
+    init_cs(PD0, &DDRD);
+    set_cs_high(PD0, &PORTD);
+
     // SPI
     init_spi();
 

--- a/src/general.c
+++ b/src/general.c
@@ -15,6 +15,9 @@ void init_eps(void) {
     // PEX
     init_pex(&pex);
 
+    // DAC
+    init_dac(&dac);
+
     // Shunts
     init_shunts();
 

--- a/src/heaters.c
+++ b/src/heaters.c
@@ -26,7 +26,7 @@ void set_heater_2_raw_setpoint(uint16_t raw_data) {
 }
 
 // temp - in C
-void set_heater_1_setpoint_temp(double temp) {
+void set_heater_1_temp_setpoint(double temp) {
     double res = therm_temp_to_res(temp);
     double vol = therm_res_to_vol(res);
     uint16_t raw_data = dac_vol_to_raw_data(vol);
@@ -34,7 +34,7 @@ void set_heater_1_setpoint_temp(double temp) {
 }
 
 // temp - in C
-void set_heater_2_setpoint_temp(double temp) {
+void set_heater_2_temp_setpoint(double temp) {
     double res = therm_temp_to_res(temp);
     double vol = therm_res_to_vol(res);
     uint16_t raw_data = dac_vol_to_raw_data(vol);

--- a/src/heaters.h
+++ b/src/heaters.h
@@ -8,7 +8,7 @@
 void set_heater_1_raw_setpoint(uint16_t raw_data);
 void set_heater_2_raw_setpoint(uint16_t raw_data);
 
-void set_heater_1_setpoint_temp(double temp);
-void set_heater_2_setpoint_temp(double temp);
+void set_heater_1_temp_setpoint(double temp);
+void set_heater_2_temp_setpoint(double temp);
 
 #endif

--- a/src/shunts.c
+++ b/src/shunts.c
@@ -47,8 +47,8 @@ void turn_shunts_off(void) {
 void control_shunts(void) {
     // Read battery voltage
     uint8_t channel = MEAS_PACK_VOUT;
-    fetch_channel(&adc, channel);
-    uint16_t raw_data_pos = read_channel(&adc, channel);
+    fetch_adc_channel(&adc, channel);
+    uint16_t raw_data_pos = read_adc_channel(&adc, channel);
     double batt_voltage = adc_raw_data_to_eps_vol(raw_data_pos);
     print("Battery Voltage: %.6f V\n", batt_voltage);
 

--- a/src/shunts.c
+++ b/src/shunts.c
@@ -17,8 +17,10 @@ void init_shunts(void) {
     set_pex_pin_dir(&pex, PEX_A, SHUNTS_POS_Y, OUTPUT);
     set_pex_pin_dir(&pex, PEX_A, SHUNTS_NEG_Y, OUTPUT);
 
+    // Make sure the ADC is initialized for battery voltage measurements
     init_adc(&adc);
 
+    // Turn shunts off (battery charging on) by default
     turn_shunts_off();
 }
 
@@ -48,18 +50,14 @@ void control_shunts(void) {
     // Read battery voltage
     uint8_t channel = MEAS_PACK_VOUT;
     fetch_adc_channel(&adc, channel);
-    uint16_t raw_data_pos = read_adc_channel(&adc, channel);
-    double batt_voltage = adc_raw_data_to_eps_vol(raw_data_pos);
-    print("Battery Voltage: %.6f V\n", batt_voltage);
+    uint16_t raw_data = read_adc_channel(&adc, channel);
+    double batt_voltage = adc_raw_data_to_eps_vol(raw_data);
 
+    // TODO - figure out thresholds
     // Decide whether to switch the shunts on, off, or stay the same
     if (!are_shunts_on && batt_voltage > SHUNTS_ON_THRESHOLD) {
         turn_shunts_on();
-        print("Shunts on\n");
     } else if (are_shunts_on && batt_voltage < SHUNTS_OFF_THRESHOLD) {
         turn_shunts_off();
-        print("Shunts off\n");
-    } else {
-        // No change in shunts
     }
 }

--- a/src/shunts.h
+++ b/src/shunts.h
@@ -24,7 +24,7 @@
 #define SHUNTS_ON_THRESHOLD 4.0
 // If the battery output voltage goes below this threshold,
 // the shunts should be turned off (battery charging on)
-#define SHUNTS_OFF_THRESHOLD 3.0
+#define SHUNTS_OFF_THRESHOLD 3.8
 
 extern bool are_shunts_on;
 

--- a/src/shunts.h
+++ b/src/shunts.h
@@ -12,7 +12,6 @@
 #include "measurements.h"
 
 
-
 // Shunt pins on PEX GPIOA (all on bank A)
 // For battery charging (solar panel faces)
 #define SHUNTS_POS_X 0   // +X face

--- a/src/shunts.h
+++ b/src/shunts.h
@@ -4,9 +4,7 @@
 #include <stdbool.h>
 
 #include <adc/adc.h>
-#include <adc/eps.h>
 #include <conversions/conversions.h>
-#include <pex/eps.h>
 #include <pex/pex.h>
 #include <uart/uart.h>
 


### PR DESCRIPTION
- Updated from lib-common changes
- Measurements with ADC working
- Shunts with PEX and battery readings working
- Heater voltage setpoints with DAC working
- CAN commands test (with simulated OBC) - measurements and heater control working
- Updated makefiles for 64M1
